### PR TITLE
added exception handler for json parsing in serialcom.py

### DIFF
--- a/rbpi_python/main_controller.py
+++ b/rbpi_python/main_controller.py
@@ -66,6 +66,8 @@ def get_json_messages(refresh):
 	#get the json message
 	if src.success:
 		json_msgs.append(src.jsonObj)
+	else:
+		print('%s failed to fetch json' %dt.datetime.strftime(dt.datetime.now(),TIME_FORMAT))
 
 if __name__ == "__main__":
 	runloop()

--- a/rbpi_python/serialcom.py
+++ b/rbpi_python/serialcom.py
@@ -54,10 +54,16 @@ def fetch_json_message():
 		foundJson = ((msgStr[0]=='{') & (msgStr[-1]=='}'))
 		if foundJson:
 			#deserialize json string into json obj
-			jsonObj = json.loads(msgStr)
-			success = 1
-			break
+			try:
+				jsonObj = json.loads(msgStr)
+				success = 1
+				break
+			except:
+				print('error parsing json:%s' %msgStr)
+				foundJson=False
+				attemptCount = attemptCount+1
 		else:
 			attemptCount = attemptCount+1
-	time.sleep(wait_time)		
-	
+		time.sleep(wait_time)
+	if attemptCount>=MAX_RETRY:
+		print('max attempts timeout')


### PR DESCRIPTION
frequently main_controller.py was interrupted with the following exception
`...`
`  File "/home/pi/python_code/plantlab/serialcom.py", line 57, in fetch_json_message
    jsonObj = json.loads(msgStr)`
`...`
`ValueError: Expecting : delimiter: line 1 column 583 (char 582)`

an example of a msgStr that was causing the exception:
take note of the substring --> datetim13/05/2019

`msgStr`
`     {"message_type":"sensor_reading","readings":[{"sensorid":"CT01","datetime":"13/05/2019 18:54:19","value":-127},{"sensorid":"TA01","datetim13/05/2019 18:54:19","value":32.9},{"sensorid":"HA01","datetime":"13/05/2019 18:54:20","value":67.1},{"sensorid":"TA02","datetime":"13/05/2019 18:54:21","value":31.5},{"sensorid":"HA02","datetime":"13/05/2019 18:54:22","value":84.4},{"sensorid":"TA04","datetime":"13/05/2019 18:54:23","value":31.2},{"sensorid":"HA04","datetime":"13/05/2019 18:54:24","value":77.5},{"sensorid":"TA05","datetime":"13/05/2019 18:54:25","value":31},{"sensorid":"HA05","datetime":"13/05/2019 18:54:26","value":94.5}]}`

resolved by adding a try except exception handler in serialcom.py

`	while ((s.inWaiting()>0) & (attemptCount<MAX_RETRY)): `
		`msgStr = s.readline().replace('\r\n','')`
		`foundJson = ((msgStr[0]=='{') & (msgStr[-1]=='}'))`
`		if foundJson:`
`			#deserialize json string into json obj`
`			try:`
`				jsonObj = json.loads(msgStr)`
`				success = 1`
`				break`
`			except:`
`				print('error parsing json:%s' %msgStr)`
`				foundJson=False`
`				attemptCount = attemptCount+1`
`		else:`
`			attemptCount = attemptCount+1`
`		time.sleep(wait_time)`