### PR TITLE
new dht lib, light test single color

### DIFF
--- a/arduino_c/HVAC/HVAC.ino
+++ b/arduino_c/HVAC/HVAC.ino
@@ -2,11 +2,11 @@
 #include <ArduinoJson.h>
 #include <OneWire.h> 
 #include <DallasTemperature.h>
-#include <DHT.h>
+#include <dht.h>
 #include <TimeLib.h>
 
 //General
-#define DHTTYPE DHT22   // DHT 22  (AM2302)
+//#define DHTTYPE DHT22   // DHT 22  (AM2302)
 const long DEFAULT_TIME = 1357041600; // Jan 1 2013 00:00 - in seconds
 String readingStr;
 long int delaySEC = 3;
@@ -39,7 +39,8 @@ int DHTpins[DHTSensorCount] = {5,3,2,7};
 
 // Initialize DHT sensor for normal 16mhz Arduino
 //DHT DHT01(5,DHTTYPE);
-DHT* DHTs[DHTSensorCount];
+dht DHT;
+//dht* DHTs[DHTSensorCount];
 
 // OUTPUT Controls
 int pin_FANL = 12;
@@ -103,7 +104,7 @@ void initialize_DHTreaders() {
     // initialize DHT pins?
     pinMode(DHTpins[i], INPUT);
     // instantiate the DHT reader object
-    DHTs[i] = new DHT(DHTpins[i], DHTTYPE);
+    //DHTs[i] = new dht(DHTpins[i], DHTTYPE);
   }
 }
 
@@ -202,11 +203,14 @@ String reading_DHT(int sensor_index,int readtype) {
 
   // read from the sensor
   float value;
-  DHTs[sensor_index]->begin();   
+  int chk = DHT.read22(DHTpins[sensor_index]);
+  //DHTs[sensor_index]->begin();   
   if (readtype==0) {
-    value= DHTs[sensor_index]->readTemperature();
+    value = DHT.temperature;
+    //value= DHTs[sensor_index]->readTemperature();
   } else {
-    value = DHTs[sensor_index]->readHumidity();
+    value = DHT.humidity;
+    //value = DHTs[sensor_index]->readHumidity();
   }
   delay(DHTread_MS);
 

--- a/arduino_c/lights_testing/lights_testing.ino
+++ b/arduino_c/lights_testing/lights_testing.ino
@@ -80,27 +80,38 @@ void geometry_test() {
   digitalWrite(powerPin[tp[0]],LOW);
   // turn on the channel relay
   digitalWrite(relayPin[tp[0]][tp[1]],HIGH);
-  // set the dim level to max
+  // set the dim level
   analogWrite(dimPin[tp[0]][tp[1]],geotest_lvl);  
 
-  delay(1000);
-  analogWrite(dimPin[tp[0]][tp[1]],0);  
-  digitalWrite(relayPin[tp[0]][tp[1]],LOW);
-  digitalWrite(powerPin[tp[0]],HIGH);
-
-  int tz[] = {1,2};
-  int geotest_z = 255;
-  // turn on the chamber
-  digitalWrite(powerPin[tz[0]],LOW);
-  // turn on the channel relay
-  digitalWrite(relayPin[tz[0]][tz[1]],HIGH);
+  // use this code for all 3x simultaneous
+  //digitalWrite(relayPin[tp[0]][1],HIGH);
+  //digitalWrite(relayPin[tp[0]][2],HIGH);
+  
   // set the dim level to max
-  analogWrite(dimPin[tz[0]][tz[1]],geotest_z);  
+  
+  // use this code for all 3x simultaneous
+  //analogWrite(dimPin[tp[0]][tp[1]],geotest_lvl);  
+  //analogWrite(dimPin[tp[0]][1],geotest_lvl);  
+  //analogWrite(dimPin[tp[0]][2],geotest_lvl);  
 
-  delay(1000);
-  analogWrite(dimPin[tz[0]][tz[1]],0);  
-  digitalWrite(relayPin[tz[0]][tz[1]],LOW);
-  digitalWrite(powerPin[tz[0]],HIGH);
+  //delay(1000);
+  //analogWrite(dimPin[tp[0]][tp[1]],0);  
+  //digitalWrite(relayPin[tp[0]][tp[1]],LOW);
+  //digitalWrite(powerPin[tp[0]],HIGH);
+
+  //int tz[] = {1,2};
+  //int geotest_z = 255;
+  // turn on the chamber
+  //digitalWrite(powerPin[tz[0]],LOW);
+  // turn on the channel relay
+  //digitalWrite(relayPin[tz[0]][tz[1]],HIGH);
+  // set the dim level to max
+  //analogWrite(dimPin[tz[0]][tz[1]],geotest_z);  
+
+  //delay(1000);
+  //analogWrite(dimPin[tz[0]][tz[1]],0);  
+  //digitalWrite(relayPin[tz[0]][tz[1]],LOW);
+  //digitalWrite(powerPin[tz[0]],HIGH);
     
 }
 


### PR DESCRIPTION
To get rid of the 'NaN' this update uses an  alternate library by Rob Tillaart on [Arduio wiki](http://playground.arduino.cc/Main/DHTLib) and [github repo](https://github.com/RobTillaart/Arduino/tree/master/libraries/DHTlib).
The update is to resolve original problem by recommendation from hired help who mentioned that the DHT22 'NaN' readings, is due to the Adafruit library.  

Original stackexchange post DHT [nan for reading AM2302](https://arduino.stackexchange.com/questions/65585/nan-for-reading-from-am2302-from-arduino-uno)